### PR TITLE
Fix missing journal_core module

### DIFF
--- a/journal_core/__init__.py
+++ b/journal_core/__init__.py
@@ -1,0 +1,6 @@
+"""Compatibility wrapper for the old :mod:`journal_core` package.
+
+This module now simply re-exports the public API from :mod:`journal` so that
+imports like ``import journal_core`` continue to work."""
+
+from journal import *


### PR DESCRIPTION
## Summary
- replace obsolete `journal_core` submodule with a lightweight package
- provide compatibility shim that re-exports the `journal` API

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685515cc8da883309a058caf71cb2a8a