### PR TITLE
Fix missing journal_core module

### DIFF
--- a/journal_core/__init__.py
+++ b/journal_core/__init__.py
@@ -1,0 +1,15 @@
+"""Compatibility wrapper for the legacy :mod:`journal_core` package.
+
+The original project exposed a package called ``journal_core`` which has since
+been renamed simply to :mod:`journal`.  To preserve backwards compatibility,
+this lightweight module re-exports the public API from :mod:`journal`.
+"""
+
+from importlib import import_module
+
+_j = import_module("journal")
+
+JournalEntry = _j.JournalEntry
+MemoryStorage = _j.MemoryStorage
+
+__all__ = list(_j.__all__)

--- a/tests/test_journal.py
+++ b/tests/test_journal.py
@@ -16,3 +16,14 @@ def test_list_order():
     store.add_entry(e2)
     ids = [e.id for e in store.list_entries()]
     assert ids == [e1.id, e2.id]
+
+
+def test_journal_core_alias():
+    import journal_core
+
+    assert journal_core.JournalEntry is JournalEntry
+
+    store = journal_core.MemoryStorage()
+    e = journal_core.JournalEntry(text="Alias")
+    store.add_entry(e)
+    assert store.get_entry(e.id) is e


### PR DESCRIPTION
## Summary
- replace obsolete `journal_core` submodule with a lightweight package
- provide compatibility shim that re-exports the `journal` API
- add tests confirming the alias works

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685515cc8da883309a058caf71cb2a8a